### PR TITLE
Bump cryptography from 42.0.4 to 43.0.3 (#1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==0.7.0
 aiosqlite==0.17.0
 asyncua==1.1.5
 cffi==1.14.5
-cryptography==43.0.0
+cryptography==43.0.1
 pycparser==2.20
 pyOpenSSL==24.2.1
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles==0.7.0
 aiosqlite==0.17.0
 asyncua==1.1.5
 cffi==1.14.5
-cryptography==43.0.1
+cryptography==43.0.3
 pycparser==2.20
 pyOpenSSL==24.2.1
 python-dateutil==2.8.1


### PR DESCRIPTION
Updates `cryptography` from 42.0.4 to 43.0.3
- [Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/42.0.4...43.0.3)
---
updated-dependencies:
- dependency-name: cryptography dependency-type: direct:production ...